### PR TITLE
Adds option to use doclava doclet instead of standard as a base one

### DIFF
--- a/doclet/jdk8/build.gradle
+++ b/doclet/jdk8/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     compile group: 'org.pegdown', name: 'pegdown', version: '1.6.0'
     compile files("${System.properties['java.home']}/../lib/tools.jar")
+    compileOnly group: 'com.google.doclava', name: 'doclava', version: '1.0.6'
 
     testCompile group: 'org.jsoup', name: 'jsoup', version: '1.8.3'
 }

--- a/doclet/jdk8/src/main/java/ch/raffael/mddoclet/BaseDocletWrapper.java
+++ b/doclet/jdk8/src/main/java/ch/raffael/mddoclet/BaseDocletWrapper.java
@@ -1,0 +1,148 @@
+package ch.raffael.mddoclet;
+
+import com.google.doclava.Doclava;
+import com.sun.javadoc.DocErrorReporter;
+import com.sun.javadoc.RootDoc;
+import com.sun.tools.doclets.standard.Standard;
+
+import java.io.File;
+
+/**
+ * A wrapper for the {@link com.sun.javadoc.Doclet}.
+ * Based on a fact whatever Doclava presents in classpath or not, forwards all calls to
+ * <ul>
+ *  <li>{@link Standard}, if Doclava is not found in classpath</li>
+ *  <li>{@link Doclava}, if Doclava is in classpath</li>
+ * </ul>
+ *
+ * Extra method {@link #maybeAdjustDestinationDir(File)} helps to set proper output folder.
+ *
+ * @author <a href="mailto:vladimir.grachev@gmail.com">Vladimir Grachev</a>
+ */
+class BaseDocletWrapper {
+
+    private static final boolean isDoclava;
+
+    /**
+     * Checks whatever doclava is present in classpath
+     *
+     * @return `true` if doclava is in classpath, `false` otherwise.
+     */
+    private static boolean isDoclavaAvailable() {
+        try {
+            Class.forName("com.google.doclava.Doclava");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    static {
+        isDoclava = isDoclavaAvailable();
+    }
+
+    /**
+     * Returns `true` if doclava can be used, `false` otherwise.
+     *
+     * @return `true` if doclava can be used, `false` otherwise.
+     */
+    private static boolean isDoclava() {
+        return isDoclava;
+    }
+
+    /**
+     * <p>Chooses and starts a base doclet, as specified by the Doclet specification.</p>
+     * Base doclet can be on of the following:
+     * <ul>
+     *  <li>Standard (gets chosen by default)</li>
+     *  <li>Doclava (gets chosen if doclava presents in classpath)</li>
+     * </ul>
+     *
+     * @param rootDoc The root doc.
+     *
+     * @return `true`, if process was successful.
+     *
+     * @see com.sun.javadoc.Doclet#start(RootDoc)
+     * @see com.google.doclava.Doclava#start(RootDoc)
+     */
+    static boolean start(RootDoc rootDoc) {
+        if (isDoclava) {
+            return Doclava.start(rootDoc);
+        }
+        return Standard.start(rootDoc);
+    }
+
+    /**
+     * <p>Chooses and redirects call to a base doclet,
+     * as specified by the Doclet specification.</p>
+     * Base doclet can be on of the following:
+     * <ul>
+     *  <li>Standard (gets chosen by default)</li>
+     *  <li>Doclava (gets chosen if doclava presents in classpath)</li>
+     * </ul>
+     *
+     * @param option The option name.
+     *
+     * @return The length of the option.
+     *
+     * @see com.sun.javadoc.Doclet#start(RootDoc)
+     * @see com.google.doclava.Doclava#start(RootDoc)
+     */
+    static int optionLength(String option) {
+        if (isDoclava) {
+            return Doclava.optionLength(option);
+        }
+        return Standard.optionLength(option);
+    }
+
+    /**
+     * <p>Chooses and redirects call to a base doclet,
+     * as specified by the Doclet specification.</p>
+     * Base doclet can be on of the following:
+     * <ul>
+     *  <li>Standard (gets chosen by default)</li>
+     *  <li>Doclava (gets chosen if doclava presents in classpath)</li>
+     * </ul>
+     *
+     * @param options       The command line options.
+     * @param errorReporter An error reporter to print errors.
+     *
+     * @return `true`, if the options are valid.
+     *
+     * @see com.sun.javadoc.Doclet#start(RootDoc)
+     * @see com.google.doclava.Doclava#start(RootDoc)
+     */
+    static boolean validOptions(String[][] options, DocErrorReporter errorReporter) {
+        if (isDoclava) {
+            return Doclava.validOptions(options, errorReporter);
+        }
+        return Standard.validOptions(options, errorReporter);
+    }
+
+    /**
+     * Adjusts destination dir based on which base doclet is used.
+     * Base doclet can be on of the following:
+     * <ul>
+     *  <li>Standard (gets chosen by default)</li>
+     *  <li>Doclava (gets chosen if doclava presents in classpath)</li>
+     * </ul>
+     *
+     * Doclava places generated javadocs into "reference" subfolder,
+     * having destination dir mach it is especially important for
+     * UML diagrams generation.
+     *
+     * @param original       The command line options.
+     *
+     * @return `original` if `Standard` doclet is used,
+     * `original/reference` if `Doclava` is used.
+     *
+     * @see com.sun.javadoc.Doclet#start(RootDoc)
+     * @see com.google.doclava.Doclava#start(RootDoc)
+     */
+    static File maybeAdjustDestinationDir(File original) {
+        if (isDoclava()) {
+            return new File(original, "reference");
+        }
+        return original;
+    }
+}

--- a/doclet/jdk8/src/main/java/ch/raffael/mddoclet/MarkdownDoclet.java
+++ b/doclet/jdk8/src/main/java/ch/raffael/mddoclet/MarkdownDoclet.java
@@ -43,7 +43,6 @@ import com.sun.javadoc.PackageDoc;
 import com.sun.javadoc.RootDoc;
 import com.sun.javadoc.SourcePosition;
 import com.sun.javadoc.Tag;
-import com.sun.tools.doclets.standard.Standard;
 import com.sun.tools.javadoc.Main;
 import org.parboiled.errors.ParserRuntimeException;
 
@@ -163,7 +162,7 @@ public class MarkdownDoclet implements DocErrorReporter {
                 rootDocWrapper.appendOption("-footer", HIGHLIGHT_JS_HTML);
             }
         }
-        return Standard.start(rootDocWrapper) && doclet.postProcess();
+        return BaseDocletWrapper.start(rootDocWrapper) && doclet.postProcess();
     }
 
     /**

--- a/doclet/jdk8/src/main/java/ch/raffael/mddoclet/Options.java
+++ b/doclet/jdk8/src/main/java/ch/raffael/mddoclet/Options.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.Splitter;
 import com.sun.javadoc.DocErrorReporter;
-import com.sun.tools.doclets.standard.Standard;
 import org.pegdown.Extensions;
 import org.pegdown.LinkRenderer;
 import org.pegdown.PegDownProcessor;
@@ -215,7 +214,7 @@ public class Options {
             if ( destinationDir != null ) {
                 errorReporter.printError(OPT_OUTPUT_DIR + " may only be specified once");
             }
-            setDestinationDir(new File(opt[1]));
+            setDestinationDir(BaseDocletWrapper.maybeAdjustDestinationDir(new File(opt[1])));
         }
         else if ( opt[0].equals(OPT_STYLESHEETFILE) ) {
             if ( stylesheetFile != null ) {
@@ -561,7 +560,7 @@ public class Options {
             return optionLength;
         }
 
-        return Standard.optionLength(option);
+        return BaseDocletWrapper.optionLength(option);
     }
 
     /**
@@ -577,7 +576,7 @@ public class Options {
     public static boolean validOptions(String[][] options, DocErrorReporter errorReporter) {
         options = new Options().load(options, errorReporter);
         if ( options != null ) {
-            return Standard.validOptions(options, errorReporter);
+            return BaseDocletWrapper.validOptions(options, errorReporter);
         }
         else {
             return false;


### PR DESCRIPTION
Although, [doclava](http://code.google.com/p/doclava/) has not been updated for a while
it still works and has nice features like:
 * embedded search “from the box”
 * direct links to classes
 * extra keywords like `@hide`

Since markdown doclet doesn’t actually replace the standard one,
but works on top of it, it’s quite easy to substitute it with doclava.

Current implementation checks if doclava doclet is in classpath and uses it if it is.
If doclava is not in classpath, standard doclet is used.

Example of usage in `build.gradle`:
```
        configurations {
            doclava
        }

        dependencies {
            doclava 'ch.raffael.mddoclet.markdown-doclet:jdk8:2.0+'
            doclava 'net.sourceforge.plantuml:plantuml:8059'
            doclava 'com.google.doclava:doclava:1.0.6'
        }

        javadoc {
            dependsOn project.configurations.doclava
            title = null
            options.doclet = "ch.raffael.mddoclet.MarkdownDoclet"
            options.docletpath = configurations.doclava.files.asType(List)
            options.addStringOption 'hdf project.name', “My Project“
        }

```